### PR TITLE
Optional rotation handle for selection box overlay + simplify inheritance for Vispy overlays

### DIFF
--- a/src/napari/_vispy/utils/visual.py
+++ b/src/napari/_vispy/utils/visual.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 from vispy.scene.widgets.viewbox import ViewBox
 
@@ -45,7 +47,7 @@ from napari.layers import (
 )
 from napari.utils.translations import trans
 
-layer_to_visual = {
+layer_to_visual: dict[type[Layer], type[VispyBaseLayer]] = {
     Image: VispyImageLayer,
     Labels: VispyLabelsLayer,
     Points: VispyPointsLayer,
@@ -68,7 +70,9 @@ overlay_to_visual: dict[type[Overlay], type[VispyBaseOverlay]] = {
 }
 
 
-def create_vispy_layer(layer: Layer) -> VispyBaseLayer:
+def create_vispy_layer(
+    layer: Layer, *args: Any, **kwargs: Any
+) -> VispyBaseLayer:
     """Create vispy visual for a layer based on its layer type.
 
     Parameters
@@ -81,9 +85,10 @@ def create_vispy_layer(layer: Layer) -> VispyBaseLayer:
     visual : VispyBaseLayer
         Vispy layer
     """
-    for layer_type, visual_class in layer_to_visual.items():
-        if isinstance(layer, layer_type):
-            return visual_class(layer)
+    # find the closest parent class, to maintain behaviour from #2757
+    for cls in layer.__class__.mro():
+        if cls in layer_to_visual:
+            return layer_to_visual[cls](layer, *args, **kwargs)
 
     raise TypeError(
         trans._(
@@ -108,9 +113,9 @@ def create_vispy_overlay(overlay: Overlay, **kwargs) -> VispyBaseOverlay:
     visual : VispyBaseOverlay
         Vispy overlay
     """
-    for overlay_type, visual_class in overlay_to_visual.items():
-        if isinstance(overlay, overlay_type):
-            return visual_class(overlay=overlay, **kwargs)
+    for cls in overlay.__class__.mro():
+        if cls in overlay_to_visual:
+            return overlay_to_visual[cls](overlay=overlay, **kwargs)
 
     raise TypeError(
         trans._(

--- a/src/napari/_vispy/visuals/interaction_box.py
+++ b/src/napari/_vispy/visuals/interaction_box.py
@@ -1,4 +1,7 @@
+from typing import Any, ClassVar
+
 import numpy as np
+import numpy.typing as npt
 from vispy.scene.visuals import Compound, Line
 
 from napari._vispy.visuals.markers import Markers
@@ -8,16 +11,23 @@ from napari.layers.utils.interaction_box import (
 
 
 class InteractionBox(Compound):
-    # vertices are generated according to the following scheme:
-    # (y is actually upside down in the canvas)
-    #      8
-    #      |
-    #  0---4---2    1 = position
-    #  |       |
-    #  5   9   6
-    #  |       |
-    #  1---7---3
-    _edges = np.array(
+    """Vispy element for displaying an interaction box.
+
+    Visualizes a rectangle with handles at the corners and midpoints,
+    and a rotation handle above the top center of the rectangle.
+
+    Vertices are generated according to the following scheme:
+    (y is actually upside down in the canvas)
+        8
+        |
+    0---4---2    1 = position
+    |       |
+    5   9   6
+    |       |
+    1---7---3
+    """
+
+    _edges: ClassVar[npt.NDArray[Any]] = np.array(
         [
             [0, 1],
             [1, 3],
@@ -27,7 +37,7 @@ class InteractionBox(Compound):
         ]
     )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._marker_color = (1, 1, 1, 1)
         self._marker_size = 10
         self._highlight_width = 2
@@ -38,19 +48,45 @@ class InteractionBox(Compound):
         super().__init__([Line(), Markers(antialias=0)], *args, **kwargs)
 
     @property
-    def line(self):
+    def line(self) -> Line:
+        """The interaction box line visual component."""
         return self._subvisuals[0]
 
     @property
-    def markers(self):
+    def markers(self) -> Markers:
+        """The interaction box markers visual component."""
         return self._subvisuals[1]
 
-    def set_data(self, top_left, bot_right, handles=True, selected=None):
+    def set_data(
+        self,
+        top_left: tuple[float, float],
+        bot_right: tuple[float, float],
+        handles: bool = True,
+        selected: int | None = None,
+        rotation: bool = True,
+    ) -> None:
+        """Update the visualized interaction box with new data.
+
+        Parameters
+        ----------
+        top_left : tuple[float, float]
+            The top left corner of the interaction box.
+        bot_right : tuple[float, float]
+            The bottom right corner of the interaction box.
+        handles : bool
+            Whether to show the handles of the interaction box.
+        selected : int | None
+            The index of the selected handle. If None, no handle is selected.
+        rotation : bool
+            Whether to show the rotation handle. Default is True.
+        """
         vertices = generate_interaction_box_vertices(
-            top_left, bot_right, handles=handles
+            top_left, bot_right, handles=handles, rotation=rotation
         )
 
         edges = self._edges if handles else self._edges[:4]
+        edges = edges if rotation else edges[:4]
+        markers = self._marker_symbol if rotation else self._marker_symbol[:8]
 
         self.line.set_data(pos=vertices, connect=edges)
 
@@ -63,7 +99,7 @@ class InteractionBox(Compound):
                 pos=vertices,
                 size=self._marker_size,
                 face_color=self._marker_color,
-                symbol=self._marker_symbol,
+                symbol=markers,
                 edge_width=marker_edges,
                 edge_color=self._edge_color,
             )

--- a/src/napari/components/_tests/test_interaction_box.py
+++ b/src/napari/components/_tests/test_interaction_box.py
@@ -29,11 +29,11 @@ def test_transform_box_vertices_from_bounds():
     bottom_right = 10, 10
     # works in vispy coordinates, so x and y are swapped
     vertices = generate_interaction_box_vertices(
-        top_left, bottom_right, handles=False
+        top_left, bottom_right, handles=False, rotation=True
     )
     np.testing.assert_allclose(vertices, expected[:4, ::-1])
     vertices = generate_interaction_box_vertices(
-        top_left, bottom_right, handles=True
+        top_left, bottom_right, handles=True, rotation=True
     )
     np.testing.assert_allclose(vertices, expected[:, ::-1])
 

--- a/src/napari/layers/utils/interaction_box.py
+++ b/src/napari/layers/utils/interaction_box.py
@@ -16,6 +16,7 @@ def generate_interaction_box_vertices(
     top_left: tuple[float, float],
     bot_right: tuple[float, float],
     handles: bool = True,
+    rotation: bool = True,
 ) -> np.ndarray:
     """
     Generate coordinates for all the handles in InteractionBoxHandle.
@@ -30,6 +31,8 @@ def generate_interaction_box_vertices(
         Bottom-right corner of the box
     handles : bool
         Whether to also return indices for the transformation handles.
+    rotation : bool
+        Whether to also return the rotation handle.
 
     Returns
     -------
@@ -53,9 +56,10 @@ def generate_interaction_box_vertices(
         box_height = vertices[0, 1] - vertices[1, 1]
         vertices = np.concatenate([vertices, middle_vertices])
 
-        # add the extra handle for rotation
-        extra_vertex = [middle_vertices[0] + [0, box_height * 0.1]]
-        vertices = np.concatenate([vertices, extra_vertex])
+        if rotation:
+            # add the extra handle for rotation
+            extra_vertex = [middle_vertices[0] + [0, box_height * 0.1]]
+            vertices = np.concatenate([vertices, extra_vertex])
 
     return vertices
 
@@ -82,7 +86,7 @@ def generate_transform_box_from_layer(
     # generates in vispy canvas pos, so invert x and y, and then go back
     top_left, bot_right = (tuple(point) for point in bounds.T[:, ::-1])
     return generate_interaction_box_vertices(
-        top_left, bot_right, handles=True
+        top_left, bot_right, handles=True, rotation=True
     )[:, ::-1]
 
 


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7958

# References and relevant issues

This PR is a follow-up discussion with @brisvag in reference to a zulip discussion about using overlays for ROI management in image layers (which also triggered issue #7931).

# Description

It adds an optional boolean flag `rotation` in the `InteractionBox` compound to allow the enabling/disabling of the rotation handle. By default this is kept to `True` to maintain backward compatibility with other existing overlays that take advantage of such compound. ...